### PR TITLE
fix: pin qr-code-styling to fork

### DIFF
--- a/example/package-lock.json
+++ b/example/package-lock.json
@@ -21,9 +21,9 @@
       "hasInstallScript": true,
       "license": "AGPL-3.0",
       "dependencies": {
+        "@algorandfoundation/qr-code-styling": "github:algorandfoundation/qr-code-styling",
         "canvas": "^2.11.2",
         "eventemitter3": "^5.0.1",
-        "qr-code-styling": "*",
         "socket.io-client": "^4.7.5",
         "tweetnacl": "^1.0.3",
         "uuid": "^10.0.0"

--- a/package-lock.json
+++ b/package-lock.json
@@ -13,7 +13,6 @@
         "@algorandfoundation/qr-code-styling": "github:algorandfoundation/qr-code-styling",
         "canvas": "^2.11.2",
         "eventemitter3": "^5.0.1",
-        "qr-code-styling": "github:algorandfoundation/qr-code-styling",
         "socket.io-client": "^4.7.5",
         "tweetnacl": "^1.0.3",
         "uuid": "^10.0.0"
@@ -10816,14 +10815,6 @@
           "url": "https://opencollective.com/fast-check"
         }
       ]
-    },
-    "node_modules/qr-code-styling": {
-      "version": "1.5.1",
-      "resolved": "git+ssh://git@github.com/algorandfoundation/qr-code-styling.git#f279d28f55e300270e31a034d6ade67f5a373598",
-      "license": "MIT",
-      "dependencies": {
-        "qrcode-generator": "^1.4.3"
-      }
     },
     "node_modules/qrcode-generator": {
       "version": "1.4.4",

--- a/package-lock.json
+++ b/package-lock.json
@@ -10,6 +10,7 @@
       "hasInstallScript": true,
       "license": "AGPL-3.0",
       "dependencies": {
+        "@algorandfoundation/qr-code-styling": "github:algorandfoundation/qr-code-styling",
         "canvas": "^2.11.2",
         "eventemitter3": "^5.0.1",
         "qr-code-styling": "github:algorandfoundation/qr-code-styling",
@@ -56,6 +57,14 @@
       "devDependencies": {
         "typescript": "^5.2.2",
         "vite": "^5.2.0"
+      }
+    },
+    "node_modules/@algorandfoundation/qr-code-styling": {
+      "version": "0.0.1",
+      "resolved": "git+ssh://git@github.com/algorandfoundation/qr-code-styling.git#ce8541ee1cb3b0ab2acd9926f3092d4ab217e276",
+      "license": "MIT",
+      "dependencies": {
+        "qrcode-generator": "^1.4.3"
       }
     },
     "node_modules/@ampproject/remapping": {
@@ -7140,9 +7149,9 @@
       }
     },
     "node_modules/micromatch": {
-      "version": "4.0.7",
-      "resolved": "https://registry.npmjs.org/micromatch/-/micromatch-4.0.7.tgz",
-      "integrity": "sha512-LPP/3KorzCwBxfeUuZmaR6bG2kdeHSbe0P2tY3FLRU4vYrjYz5hI4QZwV0njUx3jeuKe67YukQ1LSPZBKDqO/Q==",
+      "version": "4.0.8",
+      "resolved": "https://registry.npmjs.org/micromatch/-/micromatch-4.0.8.tgz",
+      "integrity": "sha512-PXwfBhYu0hBCPw8Dn0E+WDYb7af3dSLVWKi3HGv84IdF4TyFoC0ysxFd0Goxw7nSv4T/PzEJQxsYsEiFCKo2BA==",
       "dev": true,
       "dependencies": {
         "braces": "^3.0.3",

--- a/package-lock.json
+++ b/package-lock.json
@@ -12,7 +12,7 @@
       "dependencies": {
         "canvas": "^2.11.2",
         "eventemitter3": "^5.0.1",
-        "qr-code-styling": "*",
+        "qr-code-styling": "github:algorandfoundation/qr-code-styling",
         "socket.io-client": "^4.7.5",
         "tweetnacl": "^1.0.3",
         "uuid": "^10.0.0"
@@ -10809,9 +10809,9 @@
       ]
     },
     "node_modules/qr-code-styling": {
-      "version": "1.6.0-rc.1",
-      "resolved": "https://registry.npmjs.org/qr-code-styling/-/qr-code-styling-1.6.0-rc.1.tgz",
-      "integrity": "sha512-ModRIiW6oUnsP18QzrRYZSc/CFKFKIdj7pUs57AEVH20ajlglRpN3HukjHk0UbNMTlKGuaYl7Gt6/O5Gg2NU2Q==",
+      "version": "1.5.1",
+      "resolved": "git+ssh://git@github.com/algorandfoundation/qr-code-styling.git#f279d28f55e300270e31a034d6ade67f5a373598",
+      "license": "MIT",
       "dependencies": {
         "qrcode-generator": "^1.4.3"
       }

--- a/package.json
+++ b/package.json
@@ -71,9 +71,9 @@
     "typescript": "^5.4.5"
   },
   "dependencies": {
+    "@algorandfoundation/qr-code-styling": "github:algorandfoundation/qr-code-styling",
     "canvas": "^2.11.2",
     "eventemitter3": "^5.0.1",
-    "qr-code-styling": "github:algorandfoundation/qr-code-styling",
     "socket.io-client": "^4.7.5",
     "tweetnacl": "^1.0.3",
     "uuid": "^10.0.0"

--- a/package.json
+++ b/package.json
@@ -73,7 +73,7 @@
   "dependencies": {
     "canvas": "^2.11.2",
     "eventemitter3": "^5.0.1",
-    "qr-code-styling": "*",
+    "qr-code-styling": "github:algorandfoundation/qr-code-styling",
     "socket.io-client": "^4.7.5",
     "tweetnacl": "^1.0.3",
     "uuid": "^10.0.0"

--- a/src/signal.ts
+++ b/src/signal.ts
@@ -1,5 +1,7 @@
 import { io, ManagerOptions, Socket, SocketOptions } from 'socket.io-client';
-import QRCodeStyling, { Options as QRCodeOptions } from 'qr-code-styling';
+import QRCodeStyling, {
+  Options as QRCodeOptions,
+} from '@algorandfoundation/qr-code-styling';
 import { EventEmitter } from 'eventemitter3';
 import { attestation, DEFAULT_ATTESTATION_OPTIONS } from './attestation.js';
 import { v7 as uuidv7 } from 'uuid';
@@ -126,7 +128,7 @@ export class SignalClient extends EventEmitter {
   }
 
   static generateRequestId(): string {
-    return uuidv7()
+    return uuidv7();
   }
   attestation(
     onChallenge: (challenge: Uint8Array) => any,

--- a/test/signal.spec.ts
+++ b/test/signal.spec.ts
@@ -8,7 +8,7 @@ let getRawData = () => {
   });
 };
 // Mock QR Code
-jest.unstable_mockModule("qr-code-styling", () => {
+jest.unstable_mockModule("@algorandfoundation/qr-code-styling", () => {
   return {
     default: class QRCodeStyling {
       constructor(options) {


### PR DESCRIPTION
# ℹ Overview

- pins qr-code-styling to foundation's [fork](https://github.com/algorandfoundation/qr-code-styling)

### 📝 Related Issues

- resolves https://algorandfoundation.atlassian.net/browse/ENG-536

### ✅ Acceptance:
<!-- Use [X] to mark as completed -->

- [x] Conventional Commits
- [x] `npm test:cov` passes
