### PR TITLE
chore: bump UUID and remove types/UUID

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,17 +1,17 @@
 {
   "name": "@algorandfoundation/liquid-client",
-  "version": "1.0.0-canary.6",
+  "version": "1.0.0-canary.8",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@algorandfoundation/liquid-client",
-      "version": "1.0.0-canary.6",
+      "version": "1.0.0-canary.8",
       "license": "Apache-2.0",
       "dependencies": {
         "@algorandfoundation/algokit-utils": "^10.0.0-alpha.40",
         "eventemitter3": "^5.0.1",
-        "uuid": "^10.0.0"
+        "uuid": "^11.1.0"
       },
       "devDependencies": {
         "@codecov/vite-plugin": "^1.9.0",
@@ -23,7 +23,6 @@
         "@semantic-release/release-notes-generator": "^14.1.1",
         "@simplewebauthn/browser": "^13.2.2",
         "@types/qrcode": "^1.5.5",
-        "@types/uuid": "^10.0.0",
         "@vitest/browser": "^3.0.8",
         "@vitest/coverage-v8": "^3.0.8",
         "concurrently": "^9.1.2",
@@ -3300,13 +3299,6 @@
       "version": "3.0.3",
       "resolved": "https://registry.npmjs.org/@types/unist/-/unist-3.0.3.tgz",
       "integrity": "sha512-ko/gIFJRv177XgZsZcBwnqJN5x/Gien8qNOn0D5bQU/zAzVf9Zt3BlcUiLqhV9y4ARk0GbT3tnUiPNgnTXzc/Q==",
-      "dev": true,
-      "license": "MIT"
-    },
-    "node_modules/@types/uuid": {
-      "version": "10.0.0",
-      "resolved": "https://registry.npmjs.org/@types/uuid/-/uuid-10.0.0.tgz",
-      "integrity": "sha512-7gqG38EyHgyP1S+7+xomFtL+ZNHcKv6DwNaCZmJmo1vgMugyF3TCnXVg4t1uk89mLNwnLtnY3TpOpCOyp1/xHQ==",
       "dev": true,
       "license": "MIT"
     },
@@ -11606,16 +11598,16 @@
       "license": "MIT"
     },
     "node_modules/uuid": {
-      "version": "10.0.0",
-      "resolved": "https://registry.npmjs.org/uuid/-/uuid-10.0.0.tgz",
-      "integrity": "sha512-8XkAphELsDnEGrDxUOHB3RGvXz6TeuYSGEZBOjtTtPm2lwhGBjLgOzLHB63IUWfBpNucQjND6d3AOudO+H3RWQ==",
+      "version": "11.1.1",
+      "resolved": "https://registry.npmjs.org/uuid/-/uuid-11.1.1.tgz",
+      "integrity": "sha512-vIYxrBCC/N/K+Js3qSN88go7kIfNPssr/hHCesKCQNAjmgvYS2oqr69kIufEG+O4+PfezOH4EbIeHCfFov8ZgQ==",
       "funding": [
         "https://github.com/sponsors/broofa",
         "https://github.com/sponsors/ctavan"
       ],
       "license": "MIT",
       "bin": {
-        "uuid": "dist/bin/uuid"
+        "uuid": "dist/esm/bin/uuid"
       }
     },
     "node_modules/validate-npm-package-license": {

--- a/package.json
+++ b/package.json
@@ -74,7 +74,7 @@
   "dependencies": {
     "@algorandfoundation/algokit-utils": "^10.0.0-alpha.40",
     "eventemitter3": "^5.0.1",
-    "uuid": "^10.0.0"
+    "uuid": "^11.1.0"
   },
   "peerDependencies": {
     "qr-code-styling": "^1.9.2",
@@ -98,7 +98,6 @@
     "@semantic-release/release-notes-generator": "^14.1.1",
     "@simplewebauthn/browser": "^13.2.2",
     "@types/qrcode": "^1.5.5",
-    "@types/uuid": "^10.0.0",
     "@vitest/browser": "^3.0.8",
     "@vitest/coverage-v8": "^3.0.8",
     "concurrently": "^9.1.2",

--- a/package.json
+++ b/package.json
@@ -129,7 +129,8 @@
         {
           "assets": [
             "CHANGELOG.md",
-            "package.json"
+            "package.json",
+            "package-lock.json"
           ],
           "message": "chore(release): [skip ci] Liquid Client \n\n${nextRelease.notes}"
         }


### PR DESCRIPTION
# ℹ Overview

The UUID library past V11 has native typescript support and so there is no longer a need to import types/uuid.

https://www.npmjs.com/package/uuid

<img width="741" height="205" alt="Screenshot 2025-09-01 at 13 20 32" src="https://github.com/user-attachments/assets/a2915f49-f0bd-47a4-abc6-116c26e46dfd" />

### 📝 Related Issues

The UUID library seems to be what is causing issues for Use-Wallet, resulting in Liquid Auth being temporarily removed. This might address that underlying issue.

Regardless, even if it doesn't, this is just following the UUID package's instructions.

### ✅ Acceptance:
<!-- Use [X] to mark as completed -->

- [x] Conventional Commits
- [x] `npm test:cov` passes
