### PR TITLE
feat: allow datachannel names and media streams

### DIFF
--- a/package.json
+++ b/package.json
@@ -74,9 +74,19 @@
   "dependencies": {
     "@algorandfoundation/algokit-utils": "^10.0.0-alpha.40",
     "eventemitter3": "^5.0.1",
-    "qr-code-styling": "^1.9.2",
-    "socket.io-client": "^4.7.5",
     "uuid": "^10.0.0"
+  },
+  "peerDependencies": {
+    "qr-code-styling": "^1.9.2",
+    "socket.io-client": "^4.7.5"
+  },
+  "peerDependenciesMeta": {
+    "qr-code-styling": {
+      "optional": true
+    },
+    "socket.io-client": {
+      "optional": true
+    }
   },
   "devDependencies": {
     "@codecov/vite-plugin": "^1.9.0",

--- a/src/signal.spec.ts
+++ b/src/signal.spec.ts
@@ -66,6 +66,8 @@ describe("SignalClient", function () {
   beforeEach(async () => {
     createMocks();
     client = new SignalClient(url);
+    // @ts-expect-error accessing private property for testing
+    await client._socketPromise;
     client.emit = vi.fn();
   });
   afterEach(() => {
@@ -149,6 +151,8 @@ describe("SignalClient", function () {
     );
     // wait for an answer
     const result = client.peer(requestId, "offer");
+    await Promise.resolve();
+    await Promise.resolve();
     expect(client.emit).toHaveBeenNthCalledWith(1, "link", { requestId });
     expect(client.emit).toHaveBeenNthCalledWith(2, "link-message", linkMessageFixture);
     // Wait for the next tick
@@ -213,6 +217,8 @@ describe("SignalClient", function () {
     );
     // wait for an answer
     const result = client.peer(requestId, "offer");
+    await Promise.resolve();
+    await Promise.resolve();
     expect(client.emit).toHaveBeenNthCalledWith(1, "link", { requestId });
     expect(client.emit).toHaveBeenNthCalledWith(2, "link-message", linkMessageFixture);
     // Wait for the next tick
@@ -275,6 +281,8 @@ describe("SignalClient", function () {
     client.authenticated = true;
     // wait for an answer
     const result = client.peer(requestId, "answer");
+    await Promise.resolve();
+    await Promise.resolve();
 
     // @ts-expect-error, access private peerClient for testing
     client.peerClient.onicecandidate({
@@ -331,6 +339,8 @@ describe("SignalClient", function () {
     client.authenticated = true;
     // wait for an answer
     const result = client.peer(requestId, "answer");
+    await Promise.resolve();
+    await Promise.resolve();
 
     // @ts-expect-error, access private peerClient for testing
     client.peerClient.onicecandidate({
@@ -390,6 +400,7 @@ describe("SignalClient", function () {
       },
     );
     const result = client.link(requestId);
+    await Promise.resolve();
     expect(client.emit).toHaveBeenNthCalledWith(1, "link", { requestId });
     await expect(result).resolves.toEqual(linkMessageFixture);
     expect(client.emit).toHaveBeenNthCalledWith(2, "link-message", linkMessageFixture);
@@ -408,14 +419,16 @@ describe("SignalClient", function () {
       sdp: "offer-sdp-fixture",
     };
     const result = client.signal("offer");
+    await Promise.resolve();
     expect(client.emit).toHaveBeenNthCalledWith(1, "signal", { type: "offer" });
     socket.emit("offer-description", sdpFixture.sdp);
     await expect(result).resolves.toEqual(sdpFixture);
     expect(client.emit).toHaveBeenNthCalledWith(2, "offer-description", sdpFixture);
   });
 
-  test("close", function () {
+  test("close", async function () {
     client.close(true);
+    await Promise.resolve();
     expect(client.socket.connected).toBe(false);
     client.close();
     expect(client.requestId).toBeUndefined();

--- a/src/signal.ts
+++ b/src/signal.ts
@@ -5,8 +5,8 @@
  * @document ./signal.offer.guide.md
  * @document ./signal.answer.guide.md
  */
-import { io, type ManagerOptions, type SocketOptions } from "socket.io-client";
-import QRCodeStyling, { type Options as QRCodeOptions } from "qr-code-styling";
+import type { ManagerOptions, SocketOptions } from "socket.io-client";
+import type { Options as QRCodeOptions } from "qr-code-styling";
 import { EventEmitter } from "eventemitter3";
 import { v7 as uuidv7 } from "uuid";
 
@@ -36,6 +36,7 @@ export async function generateQRCode(
   if (typeof requestId === "undefined") throw new Error(REQUEST_IS_MISSING_MESSAGE);
   qrCodeOptions.data = generateDeepLink(url, requestId);
 
+  const { default: QRCodeStyling } = await import('qr-code-styling');
   const qrCode = new QRCodeStyling(qrCodeOptions);
   return await qrCode.getRawData("png").then((blob) => {
     if (!blob) throw new TypeError("Could not get qrcode blob");
@@ -67,7 +68,8 @@ export class SignalClient extends EventEmitter {
   requestId: string | undefined;
   peerClient: RTCPeerConnection | undefined;
   qrCodeOptions: QRCodeOptions = DEFAULT_QR_CODE_OPTIONS;
-  socket: LiquidSocket;
+  socket!: LiquidSocket;
+  private _socketPromise?: Promise<void>;
 
   /**
    *
@@ -84,10 +86,14 @@ export class SignalClient extends EventEmitter {
     this.url = url;
     if (options && "socket" in options && options.socket) {
       this.socket = options.socket;
+      this._setupSocket();
+      this._socketPromise = Promise.resolve();
     } else {
-      this.socket = io(url, options);
+      this._socketPromise = this._initSocket(url, options);
     }
+  }
 
+  private _setupSocket() {
     this.socket.on("connect", () => {
       this.emit("connect", this.socket.id);
     });
@@ -95,6 +101,15 @@ export class SignalClient extends EventEmitter {
     this.socket.on("disconnect", () => {
       this.emit("disconnect", this.socket.id);
     });
+  }
+
+  private async _initSocket(
+    url: string,
+    options: Partial<ManagerOptions & SocketOptions & { socket: LiquidSocket }>,
+  ) {
+    const { io } = await import('socket.io-client');
+    this.socket = io(url, options);
+    this._setupSocket();
   }
 
   static generateRequestId(): string {
@@ -194,7 +209,12 @@ export class SignalClient extends EventEmitter {
       ],
       iceCandidatePoolSize: 10,
     },
+    options: {
+      dataChannels?: Record<string, RTCDataChannelInit>;
+      tracks?: MediaStreamTrack[];
+    } = {},
   ): Promise<RTCDataChannel> {
+    await this._socketPromise;
     if (typeof requestId === "undefined" && typeof this.requestId === "undefined")
       throw new Error(REQUEST_IS_MISSING_MESSAGE);
     if (typeof this.requestId !== "undefined") throw new Error(REQUEST_IN_PROCESS_MESSAGE);
@@ -203,6 +223,12 @@ export class SignalClient extends EventEmitter {
       let candidatesBuffer: RTCIceCandidateInit[] = [];
       // Create Peer Connection
       this.peerClient = new RTCPeerConnection(config);
+
+      if (options.tracks) {
+        options.tracks.forEach((track) => {
+          this.peerClient?.addTrack(track);
+        });
+      }
 
       this.type = type === "offer" ? "answer" : "offer";
       // Wait for a link message
@@ -247,7 +273,12 @@ export class SignalClient extends EventEmitter {
         this.emit(`${this.type}-description`, answer.sdp);
         this.socket.emit(`${this.type}-description`, answer.sdp);
       } else {
-        const dataChannel = this.peerClient.createDataChannel("liquid");
+        const dataChannelsConfig = options.dataChannels || { liquid: {} };
+        const channels: Record<string, RTCDataChannel> = {};
+        for (const [label, init] of Object.entries(dataChannelsConfig)) {
+          channels[label] = this.peerClient.createDataChannel(label, init);
+        }
+        
         const localSdp = await this.peerClient.createOffer();
         await this.peerClient.setLocalDescription(localSdp);
         this.socket.emit(`${this.type}-description`, localSdp.sdp);
@@ -263,8 +294,10 @@ export class SignalClient extends EventEmitter {
           );
           candidatesBuffer = [];
         }
-        this.emit("data-channel", dataChannel);
-        onDataChannel(dataChannel);
+        for (const channel of Object.values(channels)) {
+          this.emit('data-channel', channel);
+        }
+        onDataChannel(channels['liquid'] || Object.values(channels)[0]);
       }
     };
 
@@ -278,6 +311,7 @@ export class SignalClient extends EventEmitter {
    * @param requestId
    */
   async link(requestId: string): Promise<LinkMessage> {
+    await this._socketPromise;
     if (typeof this.requestId !== "undefined") throw new Error(REQUEST_IN_PROCESS_MESSAGE);
     this.requestId = requestId;
     this.emit("link", { requestId });
@@ -298,6 +332,7 @@ export class SignalClient extends EventEmitter {
    * @param type
    */
   async signal(type: "offer" | "answer"): Promise<RTCSessionDescriptionInit> {
+    await this._socketPromise;
     if (!this.authenticated) throw new Error(UNAUTHENTICATED_MESSAGE);
     this.emit("signal", { type });
     return new Promise<RTCSessionDescriptionInit>((resolve) => {
@@ -310,10 +345,19 @@ export class SignalClient extends EventEmitter {
   }
 
   close(disconnect = false): void {
-    this.socket.removeAllListeners();
+    const cleanup = () => {
+      if (this.socket) {
+        this.socket.removeAllListeners();
+        if (disconnect) this.socket.disconnect();
+      }
+    };
+    if (this._socketPromise) {
+      this._socketPromise.then(cleanup).catch(() => {});
+    } else {
+      cleanup();
+    }
     delete this.requestId;
     this.authenticated = false;
-    if (disconnect) this.socket.disconnect();
     this.emit("close");
   }
 }


### PR DESCRIPTION
# ℹ Overview

Expands the peer method to include the following:

- adds data channel names
- allows media stream configuration

Also includes moving the QR code and Socket.io client to optional peer dependencies

### ✅ Acceptance:

<!-- Use [X] to mark as completed -->

- [X] Conventional Commits
- [x] `npm test:cov` passes
